### PR TITLE
Exit the FramedRead stream when an error occurs.

### DIFF
--- a/src/framed/mod.rs
+++ b/src/framed/mod.rs
@@ -46,6 +46,7 @@ impl<T, U> Framed<T, U> {
                 state: RWFrames {
                     read: ReadFrame {
                         buffer: BytesMut::with_capacity(capacity),
+                        has_errored: false,
                     },
                     write: WriteFrame::default(),
                 },

--- a/src/framed/read.rs
+++ b/src/framed/read.rs
@@ -40,6 +40,7 @@ where
                 codec: decoder,
                 state: ReadFrame {
                     buffer: BytesMut::with_capacity(capacity),
+                    has_errored: false,
                 },
             },
         }


### PR DESCRIPTION
This better matches the behavior of `tokio_util`, and other code expects this behavior (specifically the only consumers of this crate, `lspower` and `tower-lsp`).